### PR TITLE
internal/ethapi: Fix eth_getBlockReceipts

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -111,7 +111,7 @@ func (ec *Client) PeerCount(ctx context.Context) (uint64, error) {
 // BlockReceipts returns the receipts of a given block number or hash
 func (ec *Client) BlockReceipts(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) ([]*types.Receipt, error) {
 	var r []*types.Receipt
-	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash)
+	err := ec.c.CallContext(ctx, &r, "eth_getBlockReceipts", blockNrOrHash.String())
 	if err == nil && r == nil {
 		return nil, ethereum.NotFound
 	}


### PR DESCRIPTION
There is an issue. After marshaling rpc.BlockNumberOrHash we have e.g. {"jsonrpc":"2.0","id":3,"method":"eth_getBlockReceipts","params":[{"blockNumber":"0x2"}]} instead of {"jsonrpc":"2.0","id":3,"method":"eth_getBlockReceipts","params":["0x2"]} and invalid response.